### PR TITLE
Return AVERROR_EOF from read_packet at EOF instead of 0

### DIFF
--- a/src/core/decode.cpp
+++ b/src/core/decode.cpp
@@ -117,7 +117,7 @@ static int read_packet(void *opaque, uint8_t *buf, int size)
         ret += fread(buf + ret, 1, size - ret, ctx->files[ctx->cur_file]);
     }
 
-    return ((int) ret);
+    return ret == 0 ? AVERROR_EOF : static_cast<int>(ret);
 }
 
 /* Conditionally free all memebers of decodecontext. */


### PR DESCRIPTION
ffmpeg's examples/avio_reading.c does that as well, and looking through that file's history reveals that this return was added in 2017. I presume something must've changed in libav* internals but this shouldn't break older ffmpegs.